### PR TITLE
ignore when word under cursor is blank

### DIFF
--- a/autoload/illuminate.vim
+++ b/autoload/illuminate.vim
@@ -92,6 +92,9 @@ fun! s:illuminate(...) abort
 endf
 
 fun! s:match_word(word) abort
+  if (a:word ==# '\<\>') " ignore blank
+    return
+  endif 
   if g:Illuminate_highlightUnderCursor
     silent! call matchadd("illuminatedWord", '\V' . a:word, s:priority, s:match_id)
   else


### PR DESCRIPTION
Hi, @RRethy 

I found a problem with editing the content including Japanese.

Some Japanese word is hightlighted when no charactor is under the cursor.
![problem](https://i.gyazo.com/1d6d71bae3552ee661c06a69c187ffa5.gif)

So, I fixed not to highlight when it was blank.
![fixed](https://i.gyazo.com/a89f5c8e7cd4bf5cd80cabb0391b4976.gif)