### PR TITLE
Use `strcharpart` instead of list splicing for backwards compatibility

### DIFF
--- a/autoload/illuminate.vim
+++ b/autoload/illuminate.vim
@@ -104,12 +104,10 @@ endf
 fun! s:get_cur_word() abort
   let line = getline('.')
   let col = col('.') - 1
-  if v:version < 800
-    " https://github.com/RRethy/vim-illuminate/pull/24
-    let word = expand('<cword>')
-  else
-    let word = matchstr(line[:col], '\k*$') . matchstr(line[col:], '^\k*')[1:]
-  endif
+  let left_part = strpart(line, 0, col + 1)
+  let right_part = strpart(line, col, col('$'))
+  let word = matchstr(left_part, '\k*$') . matchstr(right_part, '^\k*')[1:]
+
   return '\<' . escape(word, '/\?') . '\>'
 endf
 

--- a/plugin/illuminate.vim
+++ b/plugin/illuminate.vim
@@ -23,7 +23,7 @@ if has("autocmd")
     autocmd InsertEnter * call illuminate#on_insert_entered()
   augroup END
 else
-  echoerr 'Illuminate requires vim compiled with +autocmd'
+  echoerr 'Illuminate requires Vim compiled with +autocmd'
   finish
 endif
 " }}}


### PR DESCRIPTION
As suggested in https://github.com/RRethy/vim-illuminate/pull/24#issuecomment-459327291, use `strcharpart` instead of list splicing to fix backwards compatibility issues with Vim versions older than 800.

I want this to be manually tested on an older version of Vim before getting merged, if someone tests it comment below. If there are no testers within a few weeks, I'll checkout an old Vim version and test it.