### PR TITLE
Fix illumination not changing for differently cased words

### DIFF
--- a/autoload/illuminate.vim
+++ b/autoload/illuminate.vim
@@ -19,7 +19,7 @@ fun! illuminate#on_cursor_moved() abort
     return
   endif
 
-  if (s:previous_match != s:get_cur_word())
+  if (s:previous_match !=# s:get_cur_word())
     call s:remove_illumination()
   else
     return


### PR DESCRIPTION
This fixes cases where moving to text that only differs in case
wouldn't change the illumination, when the user has `'ignorecase'` set.

For example, in a file with the following contents and the cursor
on the first line, only the strings "abc" will be highlighted, but
moving onto "ABC" doesn't change this to highlight the "ABC" strings.

```
abc
ABC
abc
ABC
```