### PR TITLE
Add file type whitelist

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ illuminate can also be disabled for various filetypes using the following:
 let g:Illuminate_ftblacklist = ['nerdtree']
 ```
 
+Or you can enable it only for certain filetypes with:
+```vim
+let g:Illuminate_ftwhitelist = ['vim', 'sh', 'python']
+```
+
 Lastly, by default the highlighting will be done with the hl-group `CursorLine` since that is in my opinion the nicest. It can however be overridden using the following or something similar:
 ```vim
 hi illuminatedWord cterm=underline gui=underline

--- a/autoload/illuminate.vim
+++ b/autoload/illuminate.vim
@@ -117,10 +117,15 @@ endf
 
 fun! s:should_illuminate_file() abort
   if !exists('g:Illuminate_ftblacklist')
+    " Blacklist empty filetype by default
     let g:Illuminate_ftblacklist=['']
+  endif
+  if !exists('g:Illuminate_ftwhitelist')
+    let g:Illuminate_ftwhitelist=[]
   endif
 
   return index(g:Illuminate_ftblacklist, &filetype) < 0
+        \ && (empty(g:Illuminate_ftwhitelist) || index(g:Illuminate_ftwhitelist, &filetype) >= 0)
 endf
 
 fun! s:should_illuminate_word() abort

--- a/doc/illuminate.txt
+++ b/doc/illuminate.txt
@@ -69,6 +69,18 @@ g:Illuminate_ftblacklist.
 >
     let g:Illuminate_ftblacklist = ['nerdtree']
 
+If you prefer, however, to enable |illuminate| only for a handful of filetypes
+you can use g:Illuminate_ftwhitelist instead.
+
+Note: When both blacklist and whitelist are used, only the |filetypes| in
+whitelist with the exclusion of the ones from blacklist will be enabled.
+For example, with:
+>
+    let g:Illuminate_ftwhitelist = ['python', 'sh', 'nerdtree']
+    let g:Illuminate_ftblacklist = ['nerdtree']
+
+
+only `python` and `sh` will be illuminated.
 
 Lastly, by default the highlighting will be done with the |highlight-group|
 `CursorLine` since that is in my opinion the nicest. It can however be


### PR DESCRIPTION
It is useful if you want to illuminate only some file types. If whitelist is defined blacklist will exclude from whitelist. I didn't like illumination on git, help or markdown files, but I didn't want to exclude them one by one.