### PR TITLE
Configuable highlight priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,15 +33,6 @@ Illuminate will by default highlight the word under the cursor to match the beha
 let g:Illuminate_highlightUnderCursor = 0
 ```
 
-Illuminate sets highlight with priority -1.
-This may conflict with other settings and not work as expected.
-To change priority of highlight, use the following:
-
-```vim
-" Highlight priority (default: -1)
-let g:Illuminate_highlightPriority = -1
-```
-
 By default illuminate will highlight all words the cursor passes over, but for many languages, you will only want to highlight certain highlight-groups (you can determine the highlight-group of a symbol under your cursor with `:echo synIDattr(synID(line("."), col("."), 1), "name")`).
 
 You can define which highlight groups you want the illuminating to apply to. This can be done with a dict mapping a filetype to a list of highlight-groups in your vimrc such as:

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ Illuminate will by default highlight the word under the cursor to match the beha
 let g:Illuminate_highlightUnderCursor = 0
 ```
 
+Illuminate sets highlight with priority -1.
+This may conflict with other settings and not work as expected.
+To change priority of highlight, use the following:
+
 ```vim
 " Highlight priority (default: -1)
 let g:Illuminate_highlightPriority = -1

--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ Illuminate will by default highlight the word under the cursor to match the beha
 let g:Illuminate_highlightUnderCursor = 0
 ```
 
+```vim
+" Highlight priority (default: -1)
+let g:Illuminate_highlight_priority = -1
+```
+
 By default illuminate will highlight all words the cursor passes over, but for many languages, you will only want to highlight certain highlight-groups (you can determine the highlight-group of a symbol under your cursor with `:echo synIDattr(synID(line("."), col("."), 1), "name")`).
 
 You can define which highlight groups you want the illuminating to apply to. This can be done with a dict mapping a filetype to a list of highlight-groups in your vimrc such as:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ let g:Illuminate_highlightUnderCursor = 0
 
 ```vim
 " Highlight priority (default: -1)
-let g:Illuminate_highlight_priority = -1
+let g:Illuminate_highlightPriority = -1
 ```
 
 By default illuminate will highlight all words the cursor passes over, but for many languages, you will only want to highlight certain highlight-groups (you can determine the highlight-group of a symbol under your cursor with `:echo synIDattr(synID(line("."), col("."), 1), "name")`).

--- a/autoload/illuminate.vim
+++ b/autoload/illuminate.vim
@@ -2,12 +2,12 @@
 " Maintainer:	Adam P. Regasz-Rethy (RRethy) <rethy.spud@gmail.com>
 " Version: 0.4
 
-let s:priority = -1
 let s:previous_match = ''
 let s:enabled = 1
 
 let g:Illuminate_delay = get(g:, 'Illuminate_delay', 250)
 let g:Illuminate_highlightUnderCursor = get(g:, 'Illuminate_highlightUnderCursor', 1)
+let g:Illuminate_highlight_priority = get(g:, 'Illuminate_highlight_priority', -1)
 
 fun! illuminate#on_cursor_moved() abort
   if !s:should_illuminate_file()
@@ -83,9 +83,9 @@ fun! s:match_word(word) abort
     return
   endif
   if g:Illuminate_highlightUnderCursor
-    let w:match_id = matchadd('illuminatedWord', '\V' . a:word, s:priority)
+    let w:match_id = matchadd('illuminatedWord', '\V' . a:word, g:Illuminate_highlight_priority)
   else
-    let w:match_id = matchadd('illuminatedWord', '\V\(\k\*\%#\k\*\)\@\!\&' . a:word, s:priority)
+    let w:match_id = matchadd('illuminatedWord', '\V\(\k\*\%#\k\*\)\@\!\&' . a:word, g:Illuminate_highlight_priority)
   endif
 endf
 

--- a/autoload/illuminate.vim
+++ b/autoload/illuminate.vim
@@ -7,7 +7,7 @@ let s:enabled = 1
 
 let g:Illuminate_delay = get(g:, 'Illuminate_delay', 250)
 let g:Illuminate_highlightUnderCursor = get(g:, 'Illuminate_highlightUnderCursor', 1)
-let g:Illuminate_highlight_priority = get(g:, 'Illuminate_highlight_priority', -1)
+let g:Illuminate_highlightPriority = get(g:, 'Illuminate_highlightPriority', -1)
 
 fun! illuminate#on_cursor_moved() abort
   if !s:should_illuminate_file()
@@ -83,9 +83,9 @@ fun! s:match_word(word) abort
     return
   endif
   if g:Illuminate_highlightUnderCursor
-    let w:match_id = matchadd('illuminatedWord', '\V' . a:word, g:Illuminate_highlight_priority)
+    let w:match_id = matchadd('illuminatedWord', '\V' . a:word, g:Illuminate_highlightPriority)
   else
-    let w:match_id = matchadd('illuminatedWord', '\V\(\k\*\%#\k\*\)\@\!\&' . a:word, g:Illuminate_highlight_priority)
+    let w:match_id = matchadd('illuminatedWord', '\V\(\k\*\%#\k\*\)\@\!\&' . a:word, g:Illuminate_highlightPriority)
   endif
 endf
 

--- a/doc/illuminate.txt
+++ b/doc/illuminate.txt
@@ -38,6 +38,12 @@ word under the cursor, use the following:
     " Don't highlight word under cursor (default: 1)
     let g:Illuminate_highlightUnderCursor = 0
 
+Sets the priority when |illuminate| highlights.
+This value is passed as an argument to |matchadd|.
+>
+    " Highlight priority (default: -1)
+    let g:Illuminate_highlight_priority = -1
+
 By default |illuminate| will highlight all words the cursor passes over, but
 for many languages, you will only want to highlight certain |highlight-groups|
 (you can determine the highlight-group of a symbol under your cursor with

--- a/doc/illuminate.txt
+++ b/doc/illuminate.txt
@@ -42,7 +42,7 @@ Sets the priority when |illuminate| highlights.
 This value is passed as an argument to |matchadd|.
 >
     " Highlight priority (default: -1)
-    let g:Illuminate_highlight_priority = -1
+    let g:Illuminate_highlightPriority = -1
 
 By default |illuminate| will highlight all words the cursor passes over, but
 for many languages, you will only want to highlight certain |highlight-groups|


### PR DESCRIPTION
The inability to set the priority may not work in conflict with plugins that highlight other cursors.

For example, https://github.com/todesking/ruby_hl_lvar.vim has been given priority.

This problem is solved if priority can be set.
(I will also make a PR on https://github.com/todesking/ruby_hl_lvar.vim)