### PR TITLE
make navigation message optional

### DIFF
--- a/lua/illuminate.lua
+++ b/lua/illuminate.lua
@@ -136,7 +136,7 @@ function M.get_document_highlights(bufnr)
 end
 
 function M.next_reference(opt)
-    opt = vim.tbl_extend('force', {reverse=false, wrap=false, range_ordering='start'}, opt or {})
+    opt = vim.tbl_extend('force', {reverse=false, wrap=false, range_ordering='start', navigation_message=true}, opt or {})
 
     local before
     if opt.range_ordering == 'start' then
@@ -175,7 +175,9 @@ function M.next_reference(opt)
     end
     if next then
         move_cursor(next.start.line + 1, next.start.character)
-        print('['..nexti..'/'..#refs..']')
+        if navigation_message then
+            print('['..nexti..'/'..#refs..']')
+        end
     end
     return next
 end

--- a/lua/illuminate.lua
+++ b/lua/illuminate.lua
@@ -136,7 +136,7 @@ function M.get_document_highlights(bufnr)
 end
 
 function M.next_reference(opt)
-    opt = vim.tbl_extend('force', {reverse=false, wrap=false, range_ordering='start', navigation_message=true}, opt or {})
+    opt = vim.tbl_extend('force', {reverse=false, wrap=false, range_ordering='start', silent=false}, opt or {})
 
     local before
     if opt.range_ordering == 'start' then
@@ -175,7 +175,7 @@ function M.next_reference(opt)
     end
     if next then
         move_cursor(next.start.line + 1, next.start.character)
-        if navigation_message then
+        if not opt.silent then
             print('['..nexti..'/'..#refs..']')
         end
     end


### PR DESCRIPTION
Hi, thanks for this plugin!

I'm using the `next_reference` function in a mapping that accepts a count which forces me to acknowledge a number of <count> messages by pressing any key. This PR optionally removes the message, using the same flag as https://github.com/lewis6991/gitsigns.nvim uses for its `next_hunk` function. I use the following code in my lspconfig's on_attach for reference:

```lua
require('illuminate').on_attach(client)
require('which-key').register({
  ["]i"] = { function() for i=1,vim.v.count1 do require('illuminate').next_reference({wrap=true, navigation_message=false}) end end, "jump to next reference" },
  ["[i"] = { function() for i=1,vim.v.count1 do require('illuminate').next_reference({wrap=true, reverse=true, navigation_message=false}) end end, "jump to previous reference" },
  ["<leader>it"] = { require('illuminate').toggle_pause, "illuminate: toggle updates" },
})
```

The perfect solution would be to just keep the last message, but I haven't found a way to do that yet.