### PR TITLE
Pass client offset encoding to buf_highlight_references

### DIFF
--- a/lua/illuminate.lua
+++ b/lua/illuminate.lua
@@ -64,7 +64,8 @@ local function handle_document_highlight(result, bufnr, client_id)
     timers[bufnr] = vim.defer_fn(function()
         vim.lsp.util.buf_clear_references(bufnr)
         if cursor_in_references(bufnr) then
-            vim.lsp.util.buf_highlight_references(bufnr, result, client_id)
+            local client = vim.lsp.get_client_by_id(client_id)
+            vim.lsp.util.buf_highlight_references(bufnr, result, client.offset_encoding)
         end
     end, vim.g.Illuminate_delay or 17)
     table.sort(result, function(a, b)


### PR DESCRIPTION
neovim/neovim@bc722c8a74766e14aff3a8e2fc46db72ed864053 makes it so that several LSP-related functions, including `vim.lsp.util.buf_highlight_references()`, require the client's offset encoding to be explicitly passed. At the moment, this causes any cursor movement to throw the following error:

```
Error executing vim.schedule lua callback: /Users/jose/.local/share/nvim/runtime/lua/vim/lsp/util.lua:1528: offset_encoding: expected string, got number
stack traceback:
        [C]: in function 'error'
        vim/shared.lua: in function 'validate'
        /Users/jose/.local/share/nvim/runtime/lua/vim/lsp/util.lua:1528: in function 'buf_highlight_references'
        ...site/pack/packer/start/vim-illuminate/lua/illuminate.lua:68: in function ''
        vim.lua: in function ''
        vim.lua: in function <vim.lua:0>
```

This PR fixes the error by getting the client by its ID and passing its offset encoding to the utility. As far as I can tell, this shouldn't cause any changes in behavior on older Neovim versions. 