### PR TITLE
Make sure buffer is loaded before handling results

### DIFF
--- a/lua/illuminate.lua
+++ b/lua/illuminate.lua
@@ -52,7 +52,7 @@ local function cursor_in_references(bufnr)
 end
 
 local function handle_document_highlight(result, bufnr, client_id)
-    if not bufnr then return end
+    if not (bufnr and vim.api.nvim_buf_is_loaded(bufnr)) then return end
     local btimer = timers[bufnr]
     if btimer then
         vim.loop.timer_stop(btimer)


### PR DESCRIPTION
Loading and unloading a buffer before `documentHighlight` results are returned causes `vim.lsp.util.buf_clear_references` to throw an error. This PR adds an additional check to make sure the buffer is loaded before attempting to handle results. 