### PR TITLE
fix: Default-deny `dirbuf` buffers

### DIFF
--- a/lua/illuminate/config.lua
+++ b/lua/illuminate/config.lua
@@ -9,6 +9,7 @@ local config = {
     delay = 100,
     filetype_overrides = {},
     filetypes_denylist = {
+        'dirbuf',
         'dirvish',
         'fugitive',
     },


### PR DESCRIPTION
I use https://github.com/elihunter173/dirbuf.nvim quite heavily. I don't think it makes any sense for `vim-illuminate` to operate that; same logic as for dirvish! So hopefully this pull req is helpful...