### PR TITLE
Only wrap to first or last reference if wrapscan is set

### DIFF
--- a/doc/illuminate.txt
+++ b/doc/illuminate.txt
@@ -199,7 +199,8 @@ require('illuminate').unfreeze_buf()   Unfreeze the illumination on the buffer.
 require('illuminate').goto_next_reference() Move the cursor to the closest
                                        references after the cursor which it is
                                        not currently on. Wraps the buffer if on
-                                       the last reference.
+                                       the last reference and *wrapscan* is
+                                       on.
 
 
                       *illuminate-require('illuminate').goto_prev_reference()*
@@ -207,7 +208,8 @@ require('illuminate').goto_next_reference() Move the cursor to the closest
 require('illuminate').goto_prev_reference() Move the cursor to the closest
                                        references before the cursor which it is
                                        not currently on. Wraps the buffer if on
-                                       the first reference.
+                                       the first reference and *wrapscan* is
+                                       on.
 
 
                            *illuminate-require('illuminate').textobj_select()*

--- a/lua/illuminate/goto.lua
+++ b/lua/illuminate/goto.lua
@@ -14,9 +14,12 @@ function M.goto_next_reference()
     end
 
     local i = ref.bisect_left(ref.buf_get_references(bufnr), cursor_pos)
-    i = i + 1
-    if i > #ref.buf_get_references(bufnr) then
-        i = 1
+    if i + 1 > #ref.buf_get_references(bufnr) then
+        if vim.api.nvim_get_option('wrapscan') then
+            i = 1
+        end
+    else
+        i = i + 1
     end
 
     local pos, _ = unpack(ref.buf_get_references(bufnr)[i])
@@ -37,9 +40,12 @@ function M.goto_prev_reference()
     end
 
     local i = ref.bisect_left(ref.buf_get_references(bufnr), cursor_pos)
-    i = i - 1
-    if i == 0 then
-        i = #ref.buf_get_references(bufnr)
+    if i == 1 then
+        if vim.api.nvim_get_option('wrapscan') then
+            i = #ref.buf_get_references(bufnr)
+        end
+    else
+        i = i - 1
     end
 
     local pos, _ = unpack(ref.buf_get_references(bufnr)[i])

--- a/lua/illuminate/goto.lua
+++ b/lua/illuminate/goto.lua
@@ -17,11 +17,12 @@ function M.goto_next_reference()
     if i + 1 > #ref.buf_get_references(bufnr) then
         if vim.api.nvim_get_option('wrapscan') then
             i = 1
+        else
+            vim.api.nvim_err_writeln("E384: vim-illuminate: cannot go beyond LAST reference")
         end
     else
         i = i + 1
     end
-
     local pos, _ = unpack(ref.buf_get_references(bufnr)[i])
     local new_cursor_pos = { pos[1] + 1, pos[2] }
     vim.cmd('normal! m`')
@@ -43,6 +44,8 @@ function M.goto_prev_reference()
     if i == 1 then
         if vim.api.nvim_get_option('wrapscan') then
             i = #ref.buf_get_references(bufnr)
+        else
+            vim.api.nvim_err_writeln("E384: vim-illuminate: cannot go beyond FIRST reference")
         end
     else
         i = i - 1


### PR DESCRIPTION
This adds two checks for the `wrapscan` setting as well as error messages to be more consistent with (neo)vim's built-in `#` and `*` mappings that accomplish a similar task to this plugin's `<a-p>` and `<a-n>` mappings, respectively. This is especially useful when executing macros because it allows for the macro to error and stop if it has reached the last reference.