### PR TITLE
fix: check the buffer is valid or not

### DIFF
--- a/lua/illuminate/providers/lsp.lua
+++ b/lua/illuminate/providers/lsp.lua
@@ -71,6 +71,10 @@ function M.initiate_request(bufnr, winid)
             if bufs[bufnr][1] ~= id then
                 return
             end
+            if not vim.api.nvim_buf_is_valid(bufnr) then
+                bufs[bufnr][3] = {}
+                return
+            end
 
             local references = {}
             for client_id, results in pairs(client_results) do


### PR DESCRIPTION
Sometimes I use "Shatur/neovim-session-manager" to load a session, it will throw the errors because the buffer isn't valid