### PR TITLE
Add instructions to fix underline highlight issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,3 +241,22 @@ augroup illuminate_augroup
     autocmd VimEnter * hi illuminatedCurWord cterm=italic gui=italic
 augroup END
 ```
+# Troubleshooting
+
+If the highlighting you get is an underline instead of the smooth background color change, include the following in your configuration:
+
+## vimscript
+
+```viml
+hi link IlluminatedWordText Visual
+hi link IlluminatedWordRead Visual
+hi link IlluminatedWordWrite Visual
+```
+
+## lua
+
+```lua
+vim.api.nvim_set_hl(0, "IlluminatedWordText", { link = "Visual" })
+vim.api.nvim_set_hl(0, "IlluminatedWordRead", { link = "Visual" })
+vim.api.nvim_set_hl(0, "IlluminatedWordWrite", { link = "Visual" })
+```


### PR DESCRIPTION
Hi! First of all thanks for your work on this plugin.

I ran into the issue of the highlight being just being an underline of the text and after a while looking into the issues I noticed there was a solution pointed out here https://github.com/RRethy/vim-illuminate/issues/111. I tested the Lua solution myself and got the smooth highlight working.

So I think it'd be great if this was explicit in the README in case one of your users stumbles upon this issue so they can find the solution more easily. 🙌🏼 