### PR TITLE
feat: `is_paused()` to query plugin state

### DIFF
--- a/lua/illuminate.lua
+++ b/lua/illuminate.lua
@@ -283,4 +283,8 @@ function M.debug()
     require('illuminate.engine').debug()
 end
 
+function M.is_paused()
+    return require('illuminate.engine').is_paused()
+end
+
 return M

--- a/lua/illuminate/engine.lua
+++ b/lua/illuminate/engine.lua
@@ -239,4 +239,8 @@ function M.debug()
     print('`termguicolors`', vim.opt.termguicolors:get())
 end
 
+function M.is_paused()
+    return is_paused
+end
+
 return M


### PR DESCRIPTION
Currently there is no way to query the state of the plugin globally (ie modified by `:IlluminateToggle`).