### PR TITLE
Add support for a setup-method

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You'll also get `<a-n>` and `<a-p>` as keymaps to move between references and `<
 
 ```lua
 -- default configuration
-require('illuminate').configure({
+require('illuminate').configure({  -- or require('illuminate').setup({...})
     -- providers: provider used to get references in the buffer, ordered by priority
     providers = {
         'lsp',
@@ -25,7 +25,7 @@ require('illuminate').configure({
     delay = 100,
     -- filetype_overrides: filetype specific overrides.
     -- The keys are strings to represent the filetype while the values are tables that
-    -- supports the same keys passed to .configure except for filetypes_denylist and filetypes_allowlist
+    -- supports the same keys passed to .configure / .setup except for filetypes_denylist and filetypes_allowlist
     filetype_overrides = {},
     -- filetypes_denylist: filetypes to not illuminate, this overrides filetypes_allowlist
     filetypes_denylist = {
@@ -54,7 +54,7 @@ require('illuminate').configure({
     -- The `under_cursor` option is disabled when this cutoff is hit
     large_file_cutoff = nil,
     -- large_file_config: config to use for large files (based on large_file_cutoff).
-    -- Supports the same keys passed to .configure
+    -- Supports the same keys passed to .configure / .setup
     -- If nil, vim-illuminate will be disabled for large files.
     large_file_overrides = nil,
     -- min_count_to_highlight: minimum number of matches required to perform highlighting
@@ -119,6 +119,10 @@ Buffer-local toggle of the pause/resume for vim-illuminate.
 #### require('illuminate').configure(config)
 
 Override the default configuration with `config`
+
+#### require('illuminate').setup(config)
+
+Same as configure
 
 #### require('illuminate').pause()
 

--- a/doc/illuminate.txt
+++ b/doc/illuminate.txt
@@ -36,7 +36,7 @@ You’ll also get `<a-n>` and `<a-p>` as keymaps to move between references and
 
 >
     -- default configuration
-    require('illuminate').configure({
+    require('illuminate').configure({  -- or require('illuminate').setup({...})
         -- providers: provider used to get references in the buffer, ordered by priority
         providers = {
             'lsp',
@@ -47,7 +47,7 @@ You’ll also get `<a-n>` and `<a-p>` as keymaps to move between references and
         delay = 100,
         -- filetype_overrides: filetype specific overrides.
         -- The keys are strings to represent the filetype while the values are tables that
-        -- supports the same keys passed to .configure except for filetypes_denylist and filetypes_allowlist
+        -- supports the same keys passed to .configure / .setup except for filetypes_denylist and filetypes_allowlist
         filetype_overrides = {},
         -- filetypes_denylist: filetypes to not illuminate, this overrides filetypes_allowlist
         filetypes_denylist = {
@@ -76,7 +76,7 @@ You’ll also get `<a-n>` and `<a-p>` as keymaps to move between references and
         -- The `under_cursor` option is disabled when this cutoff is hit
         large_file_cutoff = nil,
         -- large_file_config: config to use for large files (based on large_file_cutoff).
-        -- Supports the same keys passed to .configure
+        -- Supports the same keys passed to .configure / .setup
         -- If nil, vim-illuminate will be disabled for large files.
         large_file_overrides = nil,
         -- min_count_to_highlight: minimum number of matches required to perform highlighting
@@ -164,6 +164,11 @@ IlluminatedWordWrite                   Highlight group used for references of
 
 require('illuminate').configure(config) Override the default configuration with
                                        `config`
+
+                              *illuminate-require('illuminate').setup(config)*
+
+require('illuminate').setup(config) Override the default configuration with
+                                   `config`
 
 
                                     *illuminate-require('illuminate').pause()*

--- a/lua/illuminate.lua
+++ b/lua/illuminate.lua
@@ -221,6 +221,10 @@ function M.configure(config)
     require('illuminate.config').set(config)
 end
 
+function M.setup(config)
+    M.configure(config)
+end
+
 function M.pause()
     require('illuminate.engine').pause()
 end


### PR DESCRIPTION
Typically, the method used to set up a plugin is called `setup`. This enables e.g. plugin managers like [lazy.nvim](https://github.com/folke/lazy.nvim) to automatically call this method.

As vim-illuminates set up method is called `configure` this unfortunately does not work. This commit adds an additional `setup` method that behaves exactly like `configure`