### PR TITLE
refactor!: remove deprecated nvim-treesitter functionality

### DIFF
--- a/lua/illuminate/providers/treesitter.lua
+++ b/lua/illuminate/providers/treesitter.lua
@@ -1,12 +1,11 @@
-local ts_utils = require('nvim-treesitter.ts_utils')
-local locals = require('nvim-treesitter.locals')
+local locals = require("nvim-treesitter.locals")
 
 local M = {}
 
 local buf_attached = {}
 
 function M.get_references(bufnr)
-    local node_at_point = ts_utils.get_node_at_cursor()
+    local node_at_point = vim.treesitter.get_node()
     if not node_at_point then
         return
     end
@@ -37,7 +36,7 @@ function M.get_references(bufnr)
 end
 
 function M.is_ready(bufnr)
-    return buf_attached[bufnr] and vim.api.nvim_buf_get_option(bufnr, 'filetype') ~= 'yaml'
+    return buf_attached[bufnr] and vim.api.nvim_buf_get_option(bufnr, "filetype") ~= "yaml"
 end
 
 function M.attach(bufnr)

--- a/plugin/illuminate.vim
+++ b/plugin/illuminate.vim
@@ -10,17 +10,6 @@ let g:loaded_illuminate = 1
 
 if has('nvim-0.7.2') && get(g:, 'Illuminate_useDeprecated', 0) != 1
 lua << EOF
-    local ok, ts = pcall(require, 'nvim-treesitter')
-    if ok then
-        ts.define_modules({
-            illuminate = {
-                module_path = 'illuminate.providers.treesitter',
-                enable = true,
-                disable = {},
-                is_supported = require('nvim-treesitter.query').has_locals,
-            }
-        })
-    end
     require('illuminate.engine').start()
     vim.api.nvim_create_user_command('IlluminatePause', require('illuminate').pause, { bang = true })
     vim.api.nvim_create_user_command('IlluminateResume', require('illuminate').resume, { bang = true })


### PR DESCRIPTION
ts_utils and modules are deprecated in the new main branch of nvim-treesitter, and master will likely be deprecated once 0.10 is out (though not removed for a while for compatibility reasons). It'd be better to adjust for that sooner rather than later, as main currently offers many benefits over master but the module usage here will prevent users from using that. Though, disabling by filetype will be unusable (until you implement something similar..) and it is a slight breaking change for users