### PR TITLE
Safely protect word escape in binary blob like files

### DIFF
--- a/lua/illuminate/providers/regex.lua
+++ b/lua/illuminate/providers/regex.lua
@@ -21,7 +21,10 @@ local function get_cur_word(bufnr, cursor)
     if config.case_insensitive_regex() then
         modifiers = modifiers .. [[\c]]
     end
-    return modifiers .. [[\<]] .. vim.fn.escape(word, [[/\]]) .. [[\>]]
+    local ok, escaped = pcall(vim.fn.escape, word, [[/\]])
+    if ok then
+      return modifiers .. [[\<]] .. escaped .. [[\>]]
+    end
 end
 
 function M.get_references(bufnr, cursor)


### PR DESCRIPTION
I accidentally opened up a PDF file in my editor and got some internal errors. This adds a small safety check when escaping words just in case a binary string is passed to it. This allows these file types to be opened without flooding the editor with errors.


Thanks for this great plugin and hope this helps!