### PR TITLE
Use new API for detecting supported method

### DIFF
--- a/lua/illuminate.lua
+++ b/lua/illuminate.lua
@@ -138,7 +138,16 @@ function M.on_cursor_moved(bufnr)
 
     -- Best-effort check if any client support textDocument/documentHighlight
     local supported = nil
-    if vim.lsp.for_each_buffer_client then
+    -- For nvim 0.10+
+    if vim.lsp.get_clients then
+        supported = false
+        for _, client in ipairs(vim.lsp.get_clients({bufnr = bufnr})) do
+            if client and client.supports_method('textDocument/documentHighlight') then
+                supported = true
+            end
+        end
+    -- For older versions
+    elseif vim.lsp.for_each_buffer_client then
         supported = false
         vim.lsp.for_each_buffer_client(bufnr, function(client)
             if client.supports_method('textDocument/documentHighlight') then

--- a/lua/illuminate/providers/lsp.lua
+++ b/lua/illuminate/providers/lsp.lua
@@ -48,7 +48,16 @@ end
 
 function M.is_ready(bufnr)
     local supported = false
-    if vim.lsp.for_each_buffer_client then
+    -- For nvim 0.10+
+    if vim.lsp.get_clients then
+        supported = false
+        for _, client in ipairs(vim.lsp.get_clients({bufnr = bufnr})) do
+            if client and client.supports_method('textDocument/documentHighlight') then
+                supported = true
+            end
+        end
+    -- For older versions
+    elseif vim.lsp.for_each_buffer_client then
         supported = false
         vim.lsp.for_each_buffer_client(bufnr, function(client)
             if client and client.supports_method('textDocument/documentHighlight') then


### PR DESCRIPTION
`vim.lsp.for_each_buffer_client` will be deprecated after nvim 0.10.