### PR TITLE
Add config.large_file_cutoff_kilobytes to handle large single line files

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ require('illuminate').configure({
     -- large_file_cutoff: number of lines at which to use large_file_config
     -- The `under_cursor` option is disabled when this cutoff is hit
     large_file_cutoff = nil,
+    -- large_file_cutoff_kilobytes: size in kilobytes at to use large_file_config
+    large_file_cutoff_kilobytes = 50,
     -- large_file_config: config to use for large files (based on large_file_cutoff).
     -- Supports the same keys passed to .configure
     -- If nil, vim-illuminate will be disabled for large files.

--- a/doc/illuminate.txt
+++ b/doc/illuminate.txt
@@ -72,6 +72,8 @@ You’ll also get `<a-n>` and `<a-p>` as keymaps to move between references and
         -- large_file_cutoff: number of lines at which to use large_file_config
         -- The `under_cursor` option is disabled when this cutoff is hit
         large_file_cutoff = nil,
+        -- large_file_cutoff_kilobytes: size in kilobytes at to use large_file_config
+        large_file_cutoff_kilobytes = 50,
         -- large_file_config: config to use for large files (based on large_file_cutoff).
         -- Supports the same keys passed to .configure
         -- If nil, vim-illuminate will be disabled for large files.

--- a/lua/illuminate/config.lua
+++ b/lua/illuminate/config.lua
@@ -21,6 +21,7 @@ local config = {
     under_cursor = true,
     max_file_lines = nil,
     large_file_cutoff = nil,
+    large_file_cutoff_kilobytes = 50,
     large_file_config = nil,
     min_count_to_highlight = 1,
     should_enable = nil,
@@ -37,12 +38,13 @@ end
 
 function M.get()
     return (
-            M.large_file_cutoff() == nil
-            or vim.fn.line('$') <= M.large_file_cutoff()
-            or M.large_file_overrides() == nil
-        )
-        and config
-        or M.large_file_overrides()
+        (M.large_file_cutoff() == nil
+        or vim.fn.line('$') <= M.large_file_cutoff())
+        and (M.large_file_cutoff_kilobytes() == nil
+        or vim.fn.getfsize(vim.api.nvim_buf_get_name(0)) <= M.large_file_cutoff_kilobytes() * 1024)
+    )
+    and config
+    or M.large_file_overrides()
 end
 
 function M.filetype_override(bufnr)
@@ -106,6 +108,10 @@ end
 
 function M.large_file_cutoff()
     return config['large_file_cutoff']
+end
+
+function M.large_file_cutoff_kilobytes()
+    return config['large_file_cutoff_kilobytes']
 end
 
 function M.large_file_overrides()

--- a/lua/illuminate/engine.lua
+++ b/lua/illuminate/engine.lua
@@ -101,6 +101,9 @@ function M.refresh_references(bufnr, winid)
         ref.buf_set_references(bufnr, {})
     elseif config.large_file_cutoff() ~= nil and vim.fn.line('$') > config.large_file_cutoff() then
         return
+    elseif config.large_file_cutoff_kilobytes() ~= nil 
+        and vim.fn.getfsize(vim.api.nvim_buf_get_name(bufnr)) > config.large_file_cutoff_kilobytes() * 1024 then
+        return
     end
     written[bufnr] = nil
 


### PR DESCRIPTION
I have defaulted it to 50kb, not sure what the right number is, probably much lower.
I encounter this error when opening a large single line json file. 

It would be nice to catch this error and disable illuminate on the buffer automatically, but I don't have time to write that right now.

```
Error detected while processing CursorMoved Autocommands for "*":                                                                                                                               
Error executing lua callback: Vim:E363: Pattern uses more memory than 'maxmempattern'                                                                                                           
stack traceback:                                                                                                                                                                                
        [C]: in function 'synID'                                                                                                                                                                
        ...m/lazy/vim-illuminate/lua/illuminate/providers/regex.lua:60: in function 'is_ready'                                                                                                  
        ...share/nvim/lazy/vim-illuminate/lua/illuminate/engine.lua:178: in function 'get_provider'                                                                                             
        ...share/nvim/lazy/vim-illuminate/lua/illuminate/engine.lua:111: in function 'refresh_references'                                                                                       
        ...share/nvim/lazy/vim-illuminate/lua/illuminate/engine.lua:50: in function <...share/nvim/lazy/vim-illuminate/lua/illuminate/engine.lua:49>      
```