### PR TITLE
Add support for upcoming nvim-treesitter changes

### DIFF
--- a/lua/illuminate/engine.lua
+++ b/lua/illuminate/engine.lua
@@ -51,10 +51,9 @@ function M.start()
         end,
     })
 
-    -- Set up auto-attach/detach for the treesitter provider.
-    -- Only make the autocmds if nvim-treesitter won't attach/detach for us (i.e. doesn't have modules) and
-    -- we can use vim.treesitter methods from nvim v0.9 onwards.
-    if not vim.g.illuminate_ts_module_defined and vim.fn.has('nvim-0.9') == 1 then
+    -- Set up auto-attach/detach for the treesitter provider if we can use builtin methods instead of
+    -- treesitter modules.
+    if vim.fn.has('nvim-0.9') == 1 then
         vim.api.nvim_create_autocmd({ 'FileType' }, {
             callback = function(details)
                 if not vim.treesitter.language.get_lang(details.match) then

--- a/lua/illuminate/engine.lua
+++ b/lua/illuminate/engine.lua
@@ -51,7 +51,7 @@ function M.start()
         end,
     })
 
-    -- Set up auto-attach/detach for the treesitter module.
+    -- Set up auto-attach/detach for the treesitter provider.
     -- Only make the autocmds if nvim-treesitter won't attach/detach for us (i.e. doesn't have modules) and
     -- we can use vim.treesitter methods from nvim v0.9 onwards.
     if not vim.g.illuminate_ts_module_defined and vim.fn.has('nvim-0.9') == 1 then

--- a/lua/illuminate/providers/treesitter.lua
+++ b/lua/illuminate/providers/treesitter.lua
@@ -1,12 +1,13 @@
-local ts_utils = require('nvim-treesitter.ts_utils')
 local locals = require('nvim-treesitter.locals')
 
 local M = {}
 
 local buf_attached = {}
 
+-- get_node is builtin in v0.9+, get_node_at_cursor is for older versions
+local get_node_at_cursor = vim.treesitter.get_node or require('nvim-treesitter.ts_utils').get_node_at_cursor
 function M.get_references(bufnr)
-    local node_at_point = ts_utils.get_node_at_cursor()
+    local node_at_point = get_node_at_cursor()
     if not node_at_point then
         return
     end

--- a/plugin/illuminate.vim
+++ b/plugin/illuminate.vim
@@ -10,17 +10,19 @@ let g:loaded_illuminate = 1
 
 if has('nvim-0.7.2') && get(g:, 'Illuminate_useDeprecated', 0) != 1
 lua << EOF
-    local ok, ts = pcall(require, 'nvim-treesitter')
-    if ok and ts.define_modules then
-        ts.define_modules({
-            illuminate = {
-                module_path = 'illuminate.providers.treesitter',
-                enable = true,
-                disable = {},
-                is_supported = require('nvim-treesitter.query').has_locals,
-            }
-        })
-        vim.g.illuminate_ts_module_defined = true
+    if vim.fn.has('nvim-0.9') == 0 then
+        -- fallback to nvim-treesitter modules
+        local ok, ts = pcall(require, 'nvim-treesitter')
+        if ok then
+            ts.define_modules({
+                illuminate = {
+                    module_path = 'illuminate.providers.treesitter',
+                    enable = true,
+                    disable = {},
+                    is_supported = require('nvim-treesitter.query').has_locals,
+                }
+            })
+        end
     end
     require('illuminate.engine').start()
     vim.api.nvim_create_user_command('IlluminatePause', require('illuminate').pause, { bang = true })

--- a/plugin/illuminate.vim
+++ b/plugin/illuminate.vim
@@ -11,7 +11,7 @@ let g:loaded_illuminate = 1
 if has('nvim-0.7.2') && get(g:, 'Illuminate_useDeprecated', 0) != 1
 lua << EOF
     local ok, ts = pcall(require, 'nvim-treesitter')
-    if ok then
+    if ok and ts.define_modules then
         ts.define_modules({
             illuminate = {
                 module_path = 'illuminate.providers.treesitter',
@@ -20,6 +20,7 @@ lua << EOF
                 is_supported = require('nvim-treesitter.query').has_locals,
             }
         })
+        vim.g.illuminate_ts_module_defined = true
     end
     require('illuminate.engine').start()
     vim.api.nvim_create_user_command('IlluminatePause', require('illuminate').pause, { bang = true })


### PR DESCRIPTION
This should remove the dependency on nvim-treesitter's modules system whenever it's not present. Closes #201.

Might need a bit more testing cause the only testing i've done is just editing various files