### PR TITLE
Add `setup()` as an alias to `configure()`

### DIFF
--- a/lua/illuminate.lua
+++ b/lua/illuminate.lua
@@ -232,6 +232,8 @@ function M.configure(config)
     require('illuminate.config').set(config)
 end
 
+M.setup = M.configure
+
 function M.pause()
     require('illuminate.engine').pause()
 end


### PR DESCRIPTION
`setup()` is a more common/standard name for a general plugin configuration function.
And with `lazy.nvim`, it allows you to just specify the `opts` table instead of a whole function call.

```lua
{
  "RRethy/vim-illuminate",
  config = function()
    require("illuminate").configure({ 
      -- stuffs
    })
  end,
},
```

```lua
{
  "RRethy/vim-illuminate",
  opts = {
    -- stuffs
  },
},
```

It's a minor QoL improvement, but it also only takes a single line.
What do you think?