### PR TITLE
fix: offset_encoding is required now in `make_position_params`

### DIFF
--- a/lua/illuminate/providers/lsp.lua
+++ b/lua/illuminate/providers/lsp.lua
@@ -78,10 +78,14 @@ function M.initiate_request(bufnr, winid)
         id = prev_id + 1
     end
 
+    local params = vim.fn.has('nvim-0.11') == 1 and function(client)
+        return vim.lsp.util.make_position_params(winid, client.offset_encoding)
+    end or vim.lsp.util.make_position_params(winid)
+
     local cancel_fn = vim.lsp.buf_request_all(
         bufnr,
         'textDocument/documentHighlight',
-        vim.lsp.util.make_position_params(winid),
+        params,
         function(client_results)
             if bufs[bufnr][1] ~= id then
                 return


### PR DESCRIPTION
Adapt to the upstream change https://github.com/neovim/neovim/commit/629483e24eed3f2c07e55e0540c553361e0345a2 to get rid of the warning message "warning: offset_encoding is required, using the offset_encoding from the first client".

Since the commit https://github.com/neovim/neovim/commit/2dcbfe78fcec5f73ce061bb24b718187b9c6b134, `params` in `buf_request` can accept a function that takes the client as a parameter. So instead of sending the same params to all servers, the params with correct offset_encoding will send to each single server.