### PR TITLE
fix(treesitter): use 'pcall' to catch require nvim-treesitter exception

### DIFF
--- a/lua/illuminate/providers/treesitter.lua
+++ b/lua/illuminate/providers/treesitter.lua
@@ -1,5 +1,3 @@
-local locals = require('nvim-treesitter.locals')
-
 local M = {}
 
 local buf_attached = {}
@@ -7,6 +5,11 @@ local buf_attached = {}
 -- get_node is builtin in v0.9+, get_node_at_cursor is for older versions
 local get_node_at_cursor = vim.treesitter.get_node or require('nvim-treesitter.ts_utils').get_node_at_cursor
 function M.get_references(bufnr)
+    local ok, locals = pcall(require, 'nvim-treesitter.locals')
+    if not ok then
+        return
+    end
+
     local node_at_point = get_node_at_cursor()
     if not node_at_point then
         return


### PR DESCRIPTION
Close #222 

As discussed in #222, This PR moves the `require("nvim-treesitter.locals")` into the method `M.get_references`, and wrap it with `pcall`. Thus it can lazily load the "nvim-treesitter" module only when users use treesitter, and eliminate the exception for users (such like me) who don't use the treesitter providers.

I tested this PR with:

- OS: MacOS M1 chip
- Neovim: 0.10.4 stable (installed with homebrew)