### PR TITLE
Do not use treesitter provider if treesitter is not enabled in the current buffer

### DIFF
--- a/lua/illuminate/providers/treesitter.lua
+++ b/lua/illuminate/providers/treesitter.lua
@@ -38,7 +38,7 @@ function M.get_references(bufnr)
 end
 
 function M.is_ready(bufnr)
-    return buf_attached[bufnr] and vim.api.nvim_buf_get_option(bufnr, 'filetype') ~= 'yaml'
+    return buf_attached[bufnr] and vim.api.nvim_buf_get_option(bufnr, 'filetype') ~= 'yaml' and vim.treesitter.highlighter.active[bufnr]
 end
 
 function M.attach(bufnr)


### PR DESCRIPTION
This error pops up every time I open a file without its' language parser installed (example with a toml file):
```
vim-illuminate: An internal error has occured: false"...local/share/nvim/runtime/lua/vim/treesitter/language.lua:107: no parser for 'toml' language, see :help treesitter-parsers"
```
Adding a check to make it less annoying.