### PR TITLE
fix(config): fix invalid buffer when override filetype

### DIFF
--- a/lua/illuminate/config.lua
+++ b/lua/illuminate/config.lua
@@ -47,8 +47,11 @@ function M.get()
 end
 
 function M.filetype_override(bufnr)
-    local ft = vim.api.nvim_buf_get_option(bufnr, 'filetype')
-    return M.get()['filetype_overrides'] and M.get()['filetype_overrides'][ft] or {}
+    if type(bufnr) == 'number' and vim.api.nvim_buf_is_valid(bufnr) then
+        local ft = vim.api.nvim_buf_get_option(bufnr, 'filetype')
+        return M.get()['filetype_overrides'] and M.get()['filetype_overrides'][ft] or {}
+    end
+    return {}
 end
 
 function M.providers(bufnr)


### PR DESCRIPTION
Close #226 

This PR fix an error message introduced since [db2ce0c](https://github.com/RRethy/vim-illuminate/commit/db2ce0ca4564e625fb813aca5abee5e1a9cbef96), it throws an error message:


<img width="1093" alt="image" src="https://github.com/user-attachments/assets/a470466d-8c8a-47fa-a272-5d3e8d10dd2a" />


It says `Invalid buffer id 3`, throws from this line:

https://github.com/RRethy/vim-illuminate/blob/db2ce0ca4564e625fb813aca5abee5e1a9cbef96/lua/illuminate/config.lua#L50

This PR validate whether `bufnr` is a lua number, and whether it is a valid buffer.

I tested this PR with:

- OS: MacOS M1 chip
- Neovim: 0.10.4 stable (installed with homebrew)