### PR TITLE
fix(treesitter): don't mark definition as reading access

### DIFF
--- a/lua/illuminate/providers/treesitter.lua
+++ b/lua/illuminate/providers/treesitter.lua
@@ -29,12 +29,14 @@ function M.get_references(bufnr)
 
     local usages = locals.find_usages(def_node, scope, bufnr)
     for _, node in ipairs(usages) do
-        local range = { node:range() }
-        table.insert(refs, {
-            { range[1], range[2] },
-            { range[3], range[4] },
-            vim.lsp.protocol.DocumentHighlightKind.Read,
-        })
+        if node ~= def_node then
+            local range = { node:range() }
+            table.insert(refs, {
+                { range[1], range[2] },
+                { range[3], range[4] },
+                vim.lsp.protocol.DocumentHighlightKind.Read,
+            })
+        end
     end
 
     return refs


### PR DESCRIPTION
Close https://github.com/RRethy/vim-illuminate/issues/235

When iterating over the usages, I skip the `def_node`, because it should not be marked as a read.
Thus, the `def_node` is no longer marked as a read and a write, causing problems later, but only as a write.

I've tested this with Neovim 0.11.0
