### PR TITLE
fix(treesitter): always mark definitions as writing

### DIFF
--- a/lua/illuminate/providers/treesitter.lua
+++ b/lua/illuminate/providers/treesitter.lua
@@ -17,29 +17,71 @@ function M.get_references(bufnr)
 
     local refs = {}
 
-    local def_node, scope = locals.find_definition(node_at_point, bufnr)
-    if def_node ~= node_at_point then
-        local range = { def_node:range() }
+    local maybe_def_node, scope = locals.find_definition(node_at_point, bufnr)
+    -- Now it might be that `maybe_def_node` is a definition,
+    -- but it might as well be that it is something else, for example, a comment.
+    -- Through observation (in the absense of specification of `find_usages`),
+    -- we know that for non-identifiers `find_usages(some_node)` returns `some_node`.
+    -- Thus, we cautiously ignore `maybe_def_node`,
+    -- in the sense that we don't mark it as writing yet.
+    -- We will mark it later.
+    -- If we can get back to this node through `find_usages`,
+    -- then we know that this node was a definition,
+    -- because `find_definition(some_node)` returns `some_node`,
+    -- also when `some_node` is a definition,
+    -- and `find_usages(some_node)` returns an empty list
+    -- if `some_node` isn't an identifier
+    -- (also known from oversvation, in the absense of specification).
+
+    local usages = locals.find_usages(maybe_def_node, scope, bufnr)
+    for _, node in ipairs(usages) do
+        local range = { node:range() }
+        -- If something is found through usages,
+        -- we assume that it is a read.
+        local kind = vim.lsp.protocol.DocumentHighlightKind.Read
+        -- But if it is the `maybe_def_node` that we skipped (did not mark) above
+        -- because we were not sure if it was an identifier,
+        -- we now know that it is an identifier,
+        -- because we found it through `find_usages`.
+        if node == maybe_def_node then
+            -- Yet, we cannot be sure that it is the definition of that identifier,
+            -- because some things have their definition outside of the current file,
+            -- for example, imported APIs.
+            -- Thus, we must also check if this node is a definition.
+            -- Performance: despite being in a loop, this check is done at most once,
+            -- since `usages` contains no duplicates and only one `node` equals `maybe_def_node`.
+           if is_definition(locals, node) then
+               kind = vim.lsp.protocol.DocumentHighlightKind.Write
+           end
+        end
+
         table.insert(refs, {
             { range[1], range[2] },
             { range[3], range[4] },
-            vim.lsp.protocol.DocumentHighlightKind.Write,
+            kind,
         })
     end
 
-    local usages = locals.find_usages(def_node, scope, bufnr)
-    for _, node in ipairs(usages) do
-        if node ~= def_node then
-            local range = { node:range() }
-            table.insert(refs, {
-                { range[1], range[2] },
-                { range[3], range[4] },
-                vim.lsp.protocol.DocumentHighlightKind.Read,
-            })
+    return refs
+end
+
+-- Check if `node` is marked as a defintion (`locals.definition[.something]`)
+-- Specification: https://github.com/nvim-treesitter/nvim-treesitter/blob/51bba660a89e0027929206b622c9c1cbdd995cfb/CONTRIBUTING.md#locals
+function is_definition(locals, node)
+    for _, entry in ipairs(locals.get_definitions(bufnr, 'locals.definition')) do
+        if entry.node  == node then
+            -- node marked as `locals.definition`
+            return true
+        else
+            for _, sub in pairs(entry) do
+                if sub.node == node then
+                    -- node marked as `locals.definition.something`
+                    return true
+                end
+            end
         end
     end
-
-    return refs
+    return false
 end
 
 function M.is_ready(bufnr)


### PR DESCRIPTION
Close #237

To fix the mistake I introduced in #236 for fixing #235, I explored multiple options and did much more testing than last time.

![image](https://github.com/user-attachments/assets/98f81ab2-b726-4fa4-8b47-4dee989947b0)
![image](https://github.com/user-attachments/assets/583999bd-ef04-4d71-b7b3-b5976968b71a)

Here 'vim' should be highlighted as a read, because 'vim' is not defined here. Same as before I touched anything.
![image](https://github.com/user-attachments/assets/c125d8ce-60b3-4d0d-b837-9777351ac978)

It's acceptable that 'and' is not highlighted, because it is not a reference and was not highlighted before I did anything.
![image](https://github.com/user-attachments/assets/79b34eaa-322d-4222-94af-f9f0e914a292)

I've made a custom `locals.scm` for Java, where I replaces all `locals.definition.something` with `locals.definition` to make sure that `is_definition` is behaving as expected when the definitions are not discriminated by kind.
![image](https://github.com/user-attachments/assets/93ecb80b-f144-46b4-9902-48473010ff18)
![image](https://github.com/user-attachments/assets/f58f2350-9c02-49d6-9c25-71cf7f80ff81)

Here is demonstration that nothing is highlighted when there is no word under the cursor. While working on a fix I experimented with removing the `if def_node ~= node_at_point then` guard, which lead to all kinds of junk being highlighted as writes, for example, entire commends, or entire blocks. This demonstration shows that I got rid of that.
![image](https://github.com/user-attachments/assets/118be97c-ab9e-4eb8-97c5-ecddbb8f3c32)


