### PR TITLE
Avoid triggering deprecation messages for `vim.region`

### DIFF
--- a/lua/illuminate/highlight.lua
+++ b/lua/illuminate/highlight.lua
@@ -32,7 +32,7 @@ function M.buf_highlight_references(bufnr, references)
 end
 
 function M.range(bufnr, start, finish, kind)
-    if vim.region == nil then
+    if vim.fn.has('nvim-0.12') == 1 then
         local start_l, start_col = unpack(start)
         local finish_l, finish_col = unpack(finish)
         start = { bufnr, start_l + 1, start_col + 1 }


### PR DESCRIPTION
The nil check will aslo trigger the deprecation message.