### PR TITLE
feat: remove deprecation notice from NVIM 0.11

### DIFF
--- a/lua/illuminate.lua
+++ b/lua/illuminate.lua
@@ -114,7 +114,7 @@ end
 
 function M.on_attach(client)
     M.stop_buf()
-    if client and not client.supports_method('textDocument/documentHighlight') then
+    if client and not client:supports_method('textDocument/documentHighlight') then
         return
     end
     pcall(vim.api.nvim_command, 'IlluminationDisable!')
@@ -141,16 +141,16 @@ function M.on_cursor_moved(bufnr)
     -- For nvim 0.10+
     if vim.lsp.get_clients then
         supported = false
-        for _, client in ipairs(vim.lsp.get_clients({bufnr = bufnr})) do
-            if client and client.supports_method('textDocument/documentHighlight') then
+        for _, client in ipairs(vim.lsp.get_clients({ bufnr = bufnr })) do
+            if client and client:supports_method('textDocument/documentHighlight') then
                 supported = true
             end
         end
-    -- For older versions
+        -- For older versions
     elseif vim.lsp.for_each_buffer_client then
         supported = false
         vim.lsp.for_each_buffer_client(bufnr, function(client)
-            if client.supports_method('textDocument/documentHighlight') then
+            if client:supports_method('textDocument/documentHighlight') then
                 supported = true
             end
         end)


### PR DESCRIPTION
warnings were issued on later versions of NVIM, and will stop working in 0.13