### PR TITLE
fix: Vim only maps typo Illumination* to Illuminate*

### DIFF
--- a/plugin/illuminate.vim
+++ b/plugin/illuminate.vim
@@ -56,6 +56,10 @@ augroup vim_illuminate_autocmds
 augroup END
 
 finish
+else
+  command! -nargs=0 -bang IlluminateDisable call illuminate#disable_illumination(<bang>0)
+  command! -nargs=0 -bang IlluminateEnable call illuminate#enable_illumination(<bang>0)
+  command! -nargs=0 -bang IlluminateToggle call illuminate#toggle_illumination(<bang>0)
 end
 
 " Highlight group(s) {{{
@@ -84,10 +88,5 @@ else
 endif
 " }}}
 
-" Commands {{{
-command! -nargs=0 -bang IlluminationDisable call illuminate#disable_illumination(<bang>0)
-command! -nargs=0 -bang IlluminationEnable call illuminate#enable_illumination(<bang>0)
-command! -nargs=0 -bang IlluminationToggle call illuminate#toggle_illumination(<bang>0)
-" }}} Commands:
 
 " vim: foldlevel=1 foldmethod=marker


### PR DESCRIPTION
Consistency with README and docs (`:h illuminate-commands`). This PR makes Vim and NeoVim commands the same name.

ToDo: 

- [ ] `:ILLUMINATETOGGLE`, `:ILLUMINATETOGGLEBUF`, etc. as in [docs](https://github.com/RRethy/vim-illuminate/blob/master/doc/illuminate.txt) do **not** exist. Instead `:IlluminateToggle`, `:IlluminateToggleBuf`, etc. do **yes** exist, as [README#commands](https://github.com/rrethy/vim-illuminate?tab=readme-ov-file#commands) correctly states.
- [ ] Vim lacks `:IlluminateToggleBuf` and `:IlluminationToggle!` is no longer valid. See #44