### PR TITLE
Fix for using treesitter main branch

### DIFF
--- a/lua/illuminate/engine.lua
+++ b/lua/illuminate/engine.lua
@@ -70,7 +70,7 @@ function M.start()
                     return
                 end
 
-                if not parsers.has_parser(lang) then
+                if not parsers[lang] then
                     return false
                 end
 


### PR DESCRIPTION
Treesitter is being rewritten in its `main` branch. Function `has_parser` has been removed and parsers are now just a table and can be checked more easily.