### PR TITLE
Fixup supports_method deprecation

### DIFF
--- a/lua/illuminate.lua
+++ b/lua/illuminate.lua
@@ -114,7 +114,7 @@ end
 
 function M.on_attach(client)
     M.stop_buf()
-    if client and not client.supports_method('textDocument/documentHighlight') then
+    if client and not client:supports_method('textDocument/documentHighlight') then
         return
     end
     pcall(vim.api.nvim_command, 'IlluminationDisable!')
@@ -142,7 +142,7 @@ function M.on_cursor_moved(bufnr)
     if vim.lsp.get_clients then
         supported = false
         for _, client in ipairs(vim.lsp.get_clients({bufnr = bufnr})) do
-            if client and client.supports_method('textDocument/documentHighlight') then
+            if client and client:supports_method('textDocument/documentHighlight') then
                 supported = true
             end
         end
@@ -150,7 +150,7 @@ function M.on_cursor_moved(bufnr)
     elseif vim.lsp.for_each_buffer_client then
         supported = false
         vim.lsp.for_each_buffer_client(bufnr, function(client)
-            if client.supports_method('textDocument/documentHighlight') then
+            if client:supports_method('textDocument/documentHighlight') then
                 supported = true
             end
         end)

--- a/lua/illuminate.lua
+++ b/lua/illuminate.lua
@@ -4,6 +4,14 @@ local timers = {}
 local references = {}
 local paused_bufs = {}
 
+local function client_supports_method(client, method)
+    if vim.fn.has('nvim-0.11') == 1 then
+        return client:supports_method(method)
+    else
+        return client.supports_method(method)
+    end
+end
+
 -- returns r1 < r2 based on start of range
 local function before_by_start(r1, r2)
     if r1['start'].line < r2['start'].line then return true end
@@ -114,7 +122,7 @@ end
 
 function M.on_attach(client)
     M.stop_buf()
-    if client and not client:supports_method('textDocument/documentHighlight') then
+    if client and not client_supports_method(client, 'textDocument/documentHighlight') then
         return
     end
     pcall(vim.api.nvim_command, 'IlluminationDisable!')
@@ -142,15 +150,16 @@ function M.on_cursor_moved(bufnr)
     if vim.lsp.get_clients then
         supported = false
         for _, client in ipairs(vim.lsp.get_clients({bufnr = bufnr})) do
-            if client and client:supports_method('textDocument/documentHighlight') then
+            if client and client_supports_method(client, 'textDocument/documentHighlight') then
                 supported = true
+                break
             end
         end
     -- For older versions
     elseif vim.lsp.for_each_buffer_client then
         supported = false
         vim.lsp.for_each_buffer_client(bufnr, function(client)
-            if client:supports_method('textDocument/documentHighlight') then
+            if client_supports_method(client, 'textDocument/documentHighlight') then
                 supported = true
             end
         end)


### PR DESCRIPTION
```
  - ⚠️ WARNING client.supports_method is deprecated. Feature will be removed in Nvim 0.13
    - ADVICE:
      - use client:supports_method instead.
      - stack traceback:
          /home/clay/.local/share/nvim/lazy/vim-illuminate/lua/illuminate.lua:117
          /home/clay/.config/nvim/lua/plugins/lsp.lua:46
          [C]:-1
          /usr/local/share/nvim/runtime/lua/vim/lsp/client.lua:496
          /usr/local/share/nvim/runtime/lua/vim/lsp/client.lua:1101
          /usr/local/share/nvim/runtime/lua/vim/lsp/client.lua:593
          vim/_editor.lua:0
      - stack traceback:
          /home/clay/.local/share/nvim/lazy/vim-illuminate/lua/illuminate.lua:145
          lua:1
```

Getting this message on each `nvim` launch so looked into it. Annoyingly it seems like the colon syntax is rather new. 

Tried to make a shim for it