### PR TITLE
A misspell of str_byteindex leads to a bug in nvim 0.11

### DIFF
--- a/lua/illuminate/providers/lsp.lua
+++ b/lua/illuminate/providers/lsp.lua
@@ -8,7 +8,7 @@ local function _str_byteindex_enc(line, col, encoding)
     end
 
     if vim.fn.has('nvim-0.11') == 1 then
-        return vim.str_byteindx(line, encoding, col, false)
+        return vim.str_byteindex(line, encoding, col, false)
     end
 
     if encoding == 'utf-8' then

--- a/lua/illuminate/providers/regex.lua
+++ b/lua/illuminate/providers/regex.lua
@@ -12,9 +12,8 @@ local END_WORD_REGEX = vim.regex([[\k*$]])
 -- fOo
 local function get_cur_word(bufnr, cursor)
     local line = vim.api.nvim_buf_get_lines(bufnr, cursor[1], cursor[1] + 1, false)[1]
-    -- Use character-aware slicing to handle multibyte characters correctly.
-    local left_part = vim.fn.strcharpart(line, 0, cursor[2])
-    local right_part = vim.fn.strcharpart(line, cursor[2], #line)
+    local left_part = string.sub(line, 0, cursor[2] + 1)
+    local right_part = string.sub(line, cursor[2] + 1)
     local start_idx, _ = END_WORD_REGEX:match_str(left_part)
     local _, end_idx = START_WORD_REGEX:match_str(right_part)
     local word = string.format('%s%s', string.sub(left_part, start_idx + 1), string.sub(right_part, 2, end_idx))

--- a/lua/illuminate/providers/regex.lua
+++ b/lua/illuminate/providers/regex.lua
@@ -12,8 +12,9 @@ local END_WORD_REGEX = vim.regex([[\k*$]])
 -- fOo
 local function get_cur_word(bufnr, cursor)
     local line = vim.api.nvim_buf_get_lines(bufnr, cursor[1], cursor[1] + 1, false)[1]
-    local left_part = string.sub(line, 0, cursor[2] + 1)
-    local right_part = string.sub(line, cursor[2] + 1)
+    -- Use character-aware slicing to handle multibyte characters correctly.
+    local left_part = vim.fn.strcharpart(line, 0, cursor[2])
+    local right_part = vim.fn.strcharpart(line, cursor[2], #line)
     local start_idx, _ = END_WORD_REGEX:match_str(left_part)
     local _, end_idx = START_WORD_REGEX:match_str(right_part)
     local word = string.format('%s%s', string.sub(left_part, start_idx + 1), string.sub(right_part, 2, end_idx))


### PR DESCRIPTION
Closes #246. This bug is only happening in lsp mode, so I was wondering why.

And I found the `vim.str_byteindx` (lsp.lua line 10), by correcting it the bug is resolved.