### PR TITLE
feat: add separate highlight groups for word under cursor

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,36 @@ Highlight group used for references of kind write.
 hi def IlluminatedWordWrite gui=underline cterm=underline
 ```
 
+#### IlluminatedWordCursor
+
+Highlight group used for references under the cursor (Text kind). By default, links to IlluminatedWordText.
+
+```vim
+hi def link IlluminatedWordCursor IlluminatedWordText
+```
+
+To customize:
+
+```lua
+vim.api.nvim_set_hl(0, 'IlluminatedWordCursor', { bg = '#4a4a4a', bold = true })
+```
+
+#### IlluminatedWordCursorRead
+
+Highlight group used for references under the cursor (Read kind). By default, links to IlluminatedWordRead.
+
+```vim
+hi def link IlluminatedWordCursorRead IlluminatedWordRead
+```
+
+#### IlluminatedWordCursorWrite
+
+Highlight group used for references under the cursor (Write kind). By default, links to IlluminatedWordWrite.
+
+```vim
+hi def link IlluminatedWordCursorWrite IlluminatedWordWrite
+```
+
 # Commands
 
 #### :IlluminatePause

--- a/doc/illuminate.txt
+++ b/doc/illuminate.txt
@@ -1,4 +1,4 @@
-*illuminate.txt*           For NVIM v0.8.0          Last change: 2023 March 19
+*illuminate.txt*           For NVIM v0.8.0          Last change: 2025 December 27
 
 ==============================================================================
 Table of Contents                               *illuminate-table-of-contents*
@@ -111,6 +111,42 @@ Highlight group used for references of kind write.
 
 >vim
     hi def IlluminatedWordWrite gui=underline
+<
+
+
+ILLUMINATEDWORDCURSOR                                    *IlluminatedWordCursor*
+
+Highlight group used for references under the cursor (Text kind). By default,
+links to IlluminatedWordText.
+
+>vim
+    hi def link IlluminatedWordCursor IlluminatedWordText
+<
+
+To customize:
+
+>lua
+    vim.api.nvim_set_hl(0, 'IlluminatedWordCursor', { bg = '#4a4a4a', bold = true })
+<
+
+
+ILLUMINATEDWORDCURSORREAD                            *IlluminatedWordCursorRead*
+
+Highlight group used for references under the cursor (Read kind). By default,
+links to IlluminatedWordRead.
+
+>vim
+    hi def link IlluminatedWordCursorRead IlluminatedWordRead
+<
+
+
+ILLUMINATEDWORDCURSORWRITE                          *IlluminatedWordCursorWrite*
+
+Highlight group used for references under the cursor (Write kind). By default,
+links to IlluminatedWordWrite.
+
+>vim
+    hi def link IlluminatedWordCursorWrite IlluminatedWordWrite
 <
 
 

--- a/lua/illuminate.lua
+++ b/lua/illuminate.lua
@@ -315,6 +315,9 @@ function M.set_highlight_defaults()
     hi def IlluminatedWordText guifg=none guibg=none gui=underline
     hi def IlluminatedWordRead guifg=none guibg=none gui=underline
     hi def IlluminatedWordWrite guifg=none guibg=none gui=underline
+    hi def link IlluminatedWordCursor IlluminatedWordText
+    hi def link IlluminatedWordCursorRead IlluminatedWordRead
+    hi def link IlluminatedWordCursorWrite IlluminatedWordWrite
     ]]
 end
 

--- a/lua/illuminate/highlight.lua
+++ b/lua/illuminate/highlight.lua
@@ -6,7 +6,14 @@ local M = {}
 
 local HL_NAMESPACE = vim.api.nvim_create_namespace('illuminate.highlight')
 
-local function kind_to_hl_group(kind)
+local function kind_to_hl_group(kind, is_under_cursor)
+    if is_under_cursor then
+        return kind == vim.lsp.protocol.DocumentHighlightKind.Text and 'IlluminatedWordCursor'
+            or kind == vim.lsp.protocol.DocumentHighlightKind.Read and 'IlluminatedWordCursorRead'
+            or kind == vim.lsp.protocol.DocumentHighlightKind.Write and 'IlluminatedWordCursorWrite'
+            or 'IlluminatedWordCursor'
+    end
+    
     return kind == vim.lsp.protocol.DocumentHighlightKind.Text and 'IlluminatedWordText'
         or kind == vim.lsp.protocol.DocumentHighlightKind.Read and 'IlluminatedWordRead'
         or kind == vim.lsp.protocol.DocumentHighlightKind.Write and 'IlluminatedWordWrite'
@@ -20,18 +27,20 @@ function M.buf_highlight_references(bufnr, references)
 
     local cursor_pos = util.get_cursor_pos()
     for _, reference in ipairs(references) do
-        if config.under_cursor(bufnr) or not ref.is_pos_in_ref(cursor_pos, reference) then
+        local is_under_cursor = ref.is_pos_in_ref(cursor_pos, reference)
+        if config.under_cursor(bufnr) or not is_under_cursor then
             M.range(
                 bufnr,
                 reference[1],
                 reference[2],
-                reference[3]
+                reference[3],
+                is_under_cursor
             )
         end
     end
 end
 
-function M.range(bufnr, start, finish, kind)
+function M.range(bufnr, start, finish, kind, is_under_cursor)
     if vim.fn.has('nvim-0.11') == 1 then
         local start_l, start_col = unpack(start)
         local finish_l, finish_col = unpack(finish)
@@ -43,7 +52,7 @@ function M.range(bufnr, start, finish, kind)
         for _, segment in ipairs(region) do
             local start_pos, finish_pos = unpack(segment)
             vim.api.nvim_buf_set_extmark(bufnr, HL_NAMESPACE, start_pos[2] - 1, start_pos[3] - 1, {
-                hl_group = kind_to_hl_group(kind),
+                hl_group = kind_to_hl_group(kind, is_under_cursor),
                 end_col = finish_pos[3],
                 priority = 199,
                 strict = false,
@@ -61,7 +70,7 @@ function M.range(bufnr, start, finish, kind)
                 cols[2] = 0
             end
             vim.api.nvim_buf_set_extmark(bufnr, HL_NAMESPACE, linenr, cols[1], {
-                hl_group = kind_to_hl_group(kind),
+                hl_group = kind_to_hl_group(kind, is_under_cursor),
                 end_row = end_row,
                 end_col = cols[2],
                 priority = 199,


### PR DESCRIPTION
## Summary

Adds separate highlight groups for references under the cursor, allowing customization of the word under cursor independently from other references.

## Motivation

The existing `under_cursor` configuration option controls whether the word under cursor is highlighted, but does not provide a way to style it differently from other references. This change addresses that limitation by introducing cursor-specific highlight groups.

## Changes

- Added three new highlight groups:
  - `IlluminatedWordCursor` (Text kind)
  - `IlluminatedWordCursorRead` (Read kind) 
  - `IlluminatedWordCursorWrite` (Write kind)
- Modified highlighting logic to detect cursor position and apply appropriate groups
- Updated documentation in README.md and doc/illuminate.txt

## Backward Compatibility

The change is fully backward compatible:
- New highlight groups default to linking to their non-cursor counterparts
- Visual appearance remains unchanged unless explicitly customized
- Existing `under_cursor` config behavior is preserved
- No changes required to existing configurations

## Implementation Details

The implementation modifies `lua/illuminate/highlight.lua` to:
1. Accept an `is_under_cursor` parameter in the highlighting functions
2. Detect cursor position for each reference using existing utilities
3. Select appropriate highlight group based on cursor position and LSP kind
4. Maintain compatibility with all providers (LSP, treesitter, regex)