### PR TITLE
Depend on nvim-treesitter-locals instead of nvim-treesitter:master

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ https://github.com/user-attachments/assets/fc1487cf-aa19-4238-af23-ab1ac2f5744a
 
 # Quickstart
 
-Just install the plugin and things will work *just work*, no configuration needed.
+Just install this plugin along with [nvim-treesitter-locals](https://github.com/nvim-treesitter/nvim-treesitter-locals) and things will work *just work*, no configuration needed.
 
 You'll also get `<a-n>` and `<a-p>` as keymaps to move between references and `<a-i>` as a textobject for the reference illuminated under the cursor.
 

--- a/lua/illuminate/engine.lua
+++ b/lua/illuminate/engine.lua
@@ -59,22 +59,17 @@ function M.start()
                 require('illuminate.providers.treesitter').detach(details.buf)
 
                 local lang = vim.treesitter.language.get_lang(details.match)
-                local ok, query = pcall(require, 'nvim-treesitter.query')
-                if not ok then
+                if not lang then
                     return
                 end
 
-                local parsers
-                ok, parsers = pcall(require, 'nvim-treesitter.parsers')
-                if not ok then
+                local ok, parser = pcall(vim.treesitter.get_parser, details.buf, lang, { error = false })
+                if not ok or not parser then
                     return
                 end
 
-                if not parsers.has_parser(lang) then
-                    return false
-                end
-
-                if not lang or not query.has_locals(lang) then
+                local locals = vim.api.nvim_get_runtime_file(string.format('queries/%s/locals.scm', lang), false)
+                if #locals == 0 then
                     return
                 end
 
@@ -200,7 +195,7 @@ function M.refresh_references(bufnr, winid)
             local time = vim.loop.hrtime()
             if #error_timestamps == 5 then
                 vim.notify(
-                    'vim-illuminate: An internal error has occured: ' .. vim.inspect(ok) .. vim.inspect(err),
+                    'vim-illuminate: An internal error has occured: ' .. vim.inspect(err),
                     vim.log.levels.ERROR,
                     {}
                 )

--- a/lua/illuminate/engine.lua
+++ b/lua/illuminate/engine.lua
@@ -63,13 +63,11 @@ function M.start()
                     return
                 end
 
-                local ok, parser = pcall(vim.treesitter.get_parser, details.buf, lang, { error = false })
-                if not ok or not parser then
+                if not vim.treesitter.language.add(lang) then
                     return
                 end
 
-                local locals = vim.api.nvim_get_runtime_file(string.format('queries/%s/locals.scm', lang), false)
-                if #locals == 0 then
+                if not vim.treesitter.query.get(lang, 'locals') then
                     return
                 end
 

--- a/lua/illuminate/providers/treesitter.lua
+++ b/lua/illuminate/providers/treesitter.lua
@@ -2,12 +2,29 @@ local M = {}
 
 local buf_attached = {}
 
--- get_node is builtin in v0.9+, get_node_at_cursor is for older versions
-local get_node_at_cursor = vim.treesitter.get_node or require('nvim-treesitter.ts_utils').get_node_at_cursor
 function M.get_references(bufnr)
-    local ok, locals = pcall(require, 'nvim-treesitter.locals')
-    if not ok then
-        return
+    -- get_node is builtin in v0.9+, get_node_at_cursor is for older versions
+    local get_node_at_cursor
+    local locals
+    if vim.fn.has('nvim-0.9') == 1 then
+        get_node_at_cursor = vim.treesitter.get_node
+
+        local ok
+        ok, locals = pcall(require, 'nvim-treesitter-locals.locals')
+        if not ok then
+            return
+        end
+    else
+        local ok, ts_utils = pcall(require, 'nvim-treesitter.ts_utils')
+        if not ok then
+            return
+        end
+        get_node_at_cursor = ts_utils.get_node_at_cursor
+
+        ok, locals = pcall(require, 'nvim-treesitter.locals')
+        if not ok then
+            return
+        end
     end
 
     local node_at_point = get_node_at_cursor()

--- a/lua/illuminate/providers/treesitter.lua
+++ b/lua/illuminate/providers/treesitter.lua
@@ -2,29 +2,40 @@ local M = {}
 
 local buf_attached = {}
 
+local function get_locals_module()
+    local ok, locals = pcall(require, 'nvim-treesitter-locals.locals')
+    if ok then
+        return locals
+    end
+
+    ok, locals = pcall(require, 'nvim-treesitter.locals')
+    if ok then
+        return locals
+    end
+end
+
+-- get_node is builtin in v0.9+, get_node_at_cursor is for older versions
+local function get_node_function()
+    if vim.treesitter.get_node then
+        return vim.treesitter.get_node
+    end
+
+    local ok, ts_utils = pcall(require, 'nvim-treesitter.ts_utils')
+    if ok then
+        return ts_utils.get_node_at_cursor
+    end
+end
+
+local locals, get_node_at_cursor
 function M.get_references(bufnr)
-    -- get_node is builtin in v0.9+, get_node_at_cursor is for older versions
-    local get_node_at_cursor
-    local locals
-    if vim.fn.has('nvim-0.9') == 1 then
-        get_node_at_cursor = vim.treesitter.get_node
+    locals = locals or get_locals_module()
+    if not locals then
+        return
+    end
 
-        local ok
-        ok, locals = pcall(require, 'nvim-treesitter-locals.locals')
-        if not ok then
-            return
-        end
-    else
-        local ok, ts_utils = pcall(require, 'nvim-treesitter.ts_utils')
-        if not ok then
-            return
-        end
-        get_node_at_cursor = ts_utils.get_node_at_cursor
-
-        ok, locals = pcall(require, 'nvim-treesitter.locals')
-        if not ok then
-            return
-        end
+    get_node_at_cursor = get_node_at_cursor or get_node_function()
+    if not get_node_at_cursor then
+        return
     end
 
     local node_at_point = get_node_at_cursor()

--- a/plugin/illuminate.vim
+++ b/plugin/illuminate.vim
@@ -13,7 +13,7 @@ lua << EOF
     if vim.fn.has('nvim-0.9') == 0 then
         -- fallback to nvim-treesitter modules
         local ok, ts = pcall(require, 'nvim-treesitter')
-        if ok then
+        if ok and ts.define_modules then
             ts.define_modules({
                 illuminate = {
                     module_path = 'illuminate.providers.treesitter',


### PR DESCRIPTION
This commit allows users to migrate to nvim-treesitter:main. [nvim-treesitter-locals](https://github.com/nvim-treesitter/nvim-treesitter-locals) is used as a dependency which provides a reimplementation of `find_definition` and `find_usages` from `nvim-treesitter.locals`. Backwards compatibility with nvim-treesitter:master is maintained for users of neovim version 0.8 and below.